### PR TITLE
build: Export all needed includes preventing hardcode

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -39,14 +39,14 @@ cc_library_shared {
         "src/Socket.cpp",
         "src/WebSocket.cpp",
     ],
-
-    include_dirs: [
-        "external/boringssl/include",
-        "external/zlib",
+    export_include_dirs: [
+        "src",
     ],
-
+    export_shared_lib_headers: [
+        "libz",
+        "libssl",
+    ],
     static_libs: ["libjsoncpp"],
-
     cflags: [
         "-std=c++11",
         "-O3",


### PR DESCRIPTION
Export all needed includes preventing hardcode include
path in client projects.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>